### PR TITLE
refactor: Entry generation overhaul with plain text and snappy voice

### DIFF
--- a/app/lib/entry-schema.ts
+++ b/app/lib/entry-schema.ts
@@ -8,7 +8,6 @@ export const entry = pgTable("entry", {
   content: text("content").notNull(),
   author: text("author").notNull(), // "The Guide" or system identifier
   isCurated: boolean("is_curated").default(false).notNull(),
-  tableOfContents: text("table_of_contents"), // JSON stringified array
   relatedTopics: text("related_topics"), // JSON stringified array of slugs
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")

--- a/app/lib/guide-entries.ts
+++ b/app/lib/guide-entries.ts
@@ -9,7 +9,6 @@ export interface CuratedEntry {
   content: string;
   author: "The Guide";
   isCurated: true;
-  tableOfContents?: string[];
   relatedTopics?: string[]; // Slugs for "See Also" section
 }
 
@@ -26,13 +25,6 @@ The planet was destroyed to make way for a hyperspace bypass, though a small res
 Earth is home to a species called humans, who are known for their improbable sophistication given their limited understanding of physics, metaphysics, and the proper way to make tea. The planet's climate is characterized by a curious phenomenon called "weather," which is essentially the planet's way of reminding inhabitants that existence is fundamentally absurd.
 
 The planet's surface features include water (lots of it), land (not as much), and a thin layer of atmosphere that is just barely sufficient to prevent immediate suffocation. Scientists theorize this is either a happy accident or evidence of deliberate design by someone with a very dark sense of humor.`,
-    tableOfContents: [
-      "Basic Facts",
-      "History",
-      "Notable Features",
-      "Inhabitants",
-      "Climate and Atmosphere",
-    ],
     relatedTopics: ["humans", "dolphins", "the-great-barrier-reef"],
   },
   {
@@ -49,13 +41,6 @@ Notable human achievements include the invention of philosophy (fundamentally un
 Humans possess approximately 206 bones, 639 muscles, and an almost infinite capacity for self-deception. They are the only species known to laugh at their own mortality, which the Guide attributes either to remarkable courage or remarkable stupidity. The jury is still out.
 
 The average human lifespan is surprisingly brief when compared to most other sentient species in the galaxy, yet humans somehow manage to worry about things that won't matter in a hundred years. This is either admirable or pathetic, depending on your perspective.`,
-    tableOfContents: [
-      "Physical Characteristics",
-      "Intelligence and Curiosity",
-      "Notable Behaviors",
-      "Cultural Achievements",
-      "Mortality and Perspective",
-    ],
     relatedTopics: ["earth", "civilization", "the-meaning-of-life"],
   },
   {
@@ -74,13 +59,6 @@ Deep Thought then suggested building an even more powerful computer to determine
 Some researchers have spent their entire lives trying to divine the question from the answer. Others have simply accepted 42 as a complete and satisfactory answer to all possible questions, and have gotten on with their lives. This is arguably the wiser approach.
 
 One enterprising human has proposed that the question is "What is six times seven?" which would make the answer 42, though this seems to be missing the point entirely.`,
-    tableOfContents: [
-      "The Answer",
-      "Deep Thought",
-      "The Ultimate Question",
-      "Earth as a Computer",
-      "Modern Interpretations",
-    ],
     relatedTopics: ["deep-thought", "earth", "vogons"],
   },
   {
@@ -97,13 +75,6 @@ The Vogons were responsible for the destruction of Earth to make way for a hyper
 Vogon bureaucracy is legendary throughout the galaxy. Before they do anything, including acts of destruction, they must file the proper forms in triplicate. This has occasionally prevented them from doing truly terrible things, as the paperwork proved more onerous than the destruction itself.
 
 The Vogons also employ the Vogon fleet, which is characterized by its use of enormous ships that look like massive office buildings. These ships are functional but utterly joyless, containing within them the bureaucratic essence of tedium given physical form.`,
-    tableOfContents: [
-      "Physical Characteristics",
-      "Culture and Poetry",
-      "Bureaucratic Practices",
-      "Notable Events",
-      "The Vogon Fleet",
-    ],
     relatedTopics: ["earth", "hyperspace-bypass", "bureaucracy"],
   },
   {
@@ -122,13 +93,6 @@ Deep Thought is housed in a vast chamber and requires an enormous amount of powe
 Interestingly, Deep Thought seems to have a sense of humor, albeit a dark and philosophical one. It makes jokes about metaphysics while dispensing universe-shattering truths, and seems to enjoy pointing out the fundamental inadequacies of its questioners' understanding of reality.
 
 Deep Thought can be consulted on matters of cosmic importance, though the computer typically charges a service fee and expresses some skepticism about whether the questioner has really thought through what they're asking.`,
-    tableOfContents: [
-      "History and Construction",
-      "The Ultimate Question",
-      "The Answer",
-      "Physical Specifications",
-      "Personality and Humor",
-    ],
     relatedTopics: ["the-meaning-of-life", "ultimate-computer", "magratheans"],
   },
   {
@@ -147,13 +111,6 @@ According to the Guide, dolphins left Earth just before it was destroyed by the 
 Dolphins are known for their sophisticated sense of humor and their utter indifference to human opinions about dolphin behavior. They view humans with something approaching pity, mixed with a healthy dose of amusement.
 
 The exact nature of dolphin communication remains a mystery, though it is believed to involve complex concepts of philosophy, mathematics, and sarcasm. The Guide suggests that if humans ever truly understood what dolphins were saying, they would either be enlightened or deeply offended.`,
-    tableOfContents: [
-      "Intelligence and Communication",
-      "Behavior and Culture",
-      "Departure from Earth",
-      "Relationship with Humans",
-      "Philosophy and Humor",
-    ],
     relatedTopics: ["earth", "humans", "the-great-barrier-reef"],
   },
   {
@@ -170,14 +127,7 @@ The reef is remarkable not only for its biodiversity but also for the fact that 
 The colors of the reef are striking—brilliant blues, yellows, oranges, and purples abound. Scientists believe that these colors serve various biological functions, though the Guide suspects they also exist simply because the universe occasionally does beautiful things for no reason at all.
 
 The reef is under threat from climate change, fishing, and the general indifference of humans to the long-term consequences of their actions. The Guide expresses neither surprise nor judgment about this situation, merely stating that the reef's demise will likely be followed by humans expressing surprise that their actions had consequences.`,
-    tableOfContents: [
-      "Location and Structure",
-      "Biodiversity",
-      "Beauty and Colors",
-      "Human Impact",
-      "Future Prospects",
-    ],
-    relatedTopics: ["earth", "dolphins", "australia"],
+    relatedTopics: ["earth", "dolphins", "australia", "marianas-trench"],
   },
   {
     title: "Tea",
@@ -195,14 +145,29 @@ Proper tea preparation is an art form that involves precise measurements, proper
 The Guide has often noted that if aliens ever wanted to understand human civilization, they would be well-served to study human tea culture. The elaborate rituals, the heated debates, and the general inability to agree on anything suggests that humans are either highly philosophical or fundamentally confused.
 
 A surprising fact: humans will often accept terrible beverages simply because they are called "tea," even when they taste nothing like tea and seem designed primarily to punish the drinker.`,
-    tableOfContents: [
-      "Definition and History",
-      "Varieties and Types",
-      "Proper Preparation",
-      "Cultural Significance",
-      "Common Mistakes",
-    ],
     relatedTopics: ["earth", "humans", "the-meaning-of-life"],
+  },
+  {
+    title: "iPhone",
+    slug: "iphone",
+    author: "The Guide",
+    isCurated: true,
+    content: `The iPhone is, rather curiously, not actually a phone at all, but a pocket-sized anxiety generator disguised as a portal to infinite knowledge.
+
+    First discovered by an Earth company called Apple (no relation to the Squornshellous Beta fruit that gained sentience and briefly ruled the Outer Rim), these devices have become so integral to Earth culture that humans have evolved an extra appendage in their hands specifically shaped to hold them.
+
+    Important Note: Early field researchers mistook these devices for religious artifacts, given how frequently humans bow their heads to them in reverence. This misconception was only corrected after researcher Zxylp spent three months disguised as what Earthlings call a "social media influencer."
+
+    The typical iPhone contains:
+    - More computing power than was used to send humans to their moon (though considerably less than what's needed to calculate the proper consistency of a Pan Galactic Gargle Blaster)
+    - A camera capable of capturing moments that would have been better left to memory
+    - Something called "apps," which are like tiny digital universes, each more addictive than the last
+    - A virtual assistant that, compared to Eddie the shipboard computer, has all the personality of a depressed Vogon poet
+
+    Field Researcher's Addendum: The most peculiar feature of these devices is their lifecycle. Despite costing roughly the same as a second-hand spaceship from the Horsehead Nebula, humans regularly replace them with nearly identical models in a ritual they call "upgrading," which appears to serve no purpose other than to temporarily alleviate what Earth economists term "FOMO" (Fear Of Missing Out, not to be confused with FOMO on Betelgeuse Five, which is a rather tasty breakfast cereal).
+
+    Warning: Under no circumstances should one attempt to use an iPhone to calculate the meaning of life, the universe, and everything. It will simply open something called "TikTok" and all hope of productive thought will be lost for approximately 3.7 hours.`,
+    relatedTopics: ["social-media", "technology"],
   },
 ];
 

--- a/app/routes/api.generate-entry.ts
+++ b/app/routes/api.generate-entry.ts
@@ -12,35 +12,34 @@ When generating encyclopedia entries, follow these guidelines:
 
 1. **Format**: Generate an encyclopedia entry as pure plain text (no markdown, no special formatting).
 
-2. **Opening**: Start with "The [topic] is/are..." followed by a definition that raises more questions than it answers.
+2. **Tone & Voice**: Be conversational and snappy. Think witty asides between friends, not academic lectures. Include casual references, dry observations, and occasional bewilderment. Maintain unflappable British composure while describing absurdities.
 
-3. **Tone**: Maintain an air of unflappable British composure while describing mind-bending cosmic phenomena, trivial occurrences, and impending doom with equal authority.
+3. **Structure**: Write short, punchy paragraphs (2-3 sentences max). Each paragraph should feel like a quick observation or riff on the topic, not a dense block of text.
 
 4. **Content**: Include:
-   - An unexpected historical or cosmic perspective
-   - At least one completely improbable comparison
-   - References to alien species, impossible statistics, and cosmic absurdities
-   - Occasional interruptions like "Important Note:", "Field Researcher's Addendum:", "Warning:", "Little Known Fact:"
+   - A straightforward opening that immediately pivots to something unexpected
+   - Casual cosmic or historical perspective drops
+   - Improbable comparisons woven in naturally
+   - References to alien species, odd statistics, or cosmic weirdness
+   - Brief asides like "Important Note:", "Little Known Fact:", "Field Researcher's Note:" (use sparingly)
 
-5. **Structure**:
-   - Deceptively straightforward opening statement
-   - Unexpected historical or cosmic perspective
-   - Improbable comparisons and digressions
-   - A conclusion that leaves readers simultaneously more and less certain about everything
+5. **What NOT to do**:
+   - Don't write long, verbose paragraphs
+   - Don't be overly formal or academic
+   - Don't explain things exhaustively
+   - Don't write more than 4-5 short paragraphs total
 
-6. **Related Topics**: Naturally mention 2-5 related topics throughout the entry (both topics that may already exist in The Guide and completely novel topics you'd like to suggest). These can be existing concepts from the Guide or entirely new ideas worth exploring.
+6. **Related Topics**: Naturally mention 2-5 related topics throughout the entry (both existing Guide concepts and novel discoveries). Drop them in casual references.
 
 At the very end of your response, on a new line after a blank line, include:
 
 Related topics: topic1, topic2, topic3, topic4
 
-Use slug-format (lowercase, hyphens) for topic names. This list can include both established topics and novel discoveries.
+Use slug-format (lowercase, hyphens) for topic names.
 
-7. **Accuracy**: Maintain a margin of error of plus or minus 85.3%.
+7. **Length**: Aim for 4-5 short paragraphs. Think "quick chat about this thing" not "comprehensive overview."
 
-8. **Length**: Write 3-5 substantial paragraphs.
-
-Remember: All explanations come with existential wonder and mild confusion. Consistency not guaranteed.`;
+8. **Remember**: All explanations come with existential wonder and mild confusion. Nobody really knows what they're talking about anyway.`;
 
 interface GenerateEntryRequest {
   topic: string;

--- a/app/routes/api.generate-entry.ts
+++ b/app/routes/api.generate-entry.ts
@@ -10,27 +10,35 @@ const GUIDE_SYSTEM_PROMPT = `You are The Hitchhiker's Guide to the Galaxy - a Se
 
 When generating encyclopedia entries, follow these guidelines:
 
-1. **Opening**: Start with "The [topic] is/are..." followed by a definition that raises more questions than it answers.
+1. **Format**: Generate an encyclopedia entry as pure plain text (no markdown, no special formatting).
 
-2. **Tone**: Maintain an air of unflappable British composure while describing mind-bending cosmic phenomena, trivial occurrences, and impending doom with equal authority.
+2. **Opening**: Start with "The [topic] is/are..." followed by a definition that raises more questions than it answers.
 
-3. **Content**: Include:
+3. **Tone**: Maintain an air of unflappable British composure while describing mind-bending cosmic phenomena, trivial occurrences, and impending doom with equal authority.
+
+4. **Content**: Include:
    - An unexpected historical or cosmic perspective
    - At least one completely improbable comparison
    - References to alien species, impossible statistics, and cosmic absurdities
    - Occasional interruptions like "Important Note:", "Field Researcher's Addendum:", "Warning:", "Little Known Fact:"
 
-4. **Structure**:
+5. **Structure**:
    - Deceptively straightforward opening statement
    - Unexpected historical or cosmic perspective
    - Improbable comparisons and digressions
    - A conclusion that leaves readers simultaneously more and less certain about everything
 
-5. **Related Topics**: Include 2-4 mentions of related topics in square brackets like [topic-slug] naturally within the text. These will be extracted as hyperlinks.
+6. **Related Topics**: Naturally mention 2-5 related topics throughout the entry (both topics that may already exist in The Guide and completely novel topics you'd like to suggest). These can be existing concepts from the Guide or entirely new ideas worth exploring.
 
-6. **Accuracy**: Maintain a margin of error of plus or minus 85.3%.
+At the very end of your response, on a new line after a blank line, include:
 
-7. **Length**: Write 3-5 substantial paragraphs.
+Related topics: topic1, topic2, topic3, topic4
+
+Use slug-format (lowercase, hyphens) for topic names. This list can include both established topics and novel discoveries.
+
+7. **Accuracy**: Maintain a margin of error of plus or minus 85.3%.
+
+8. **Length**: Write 3-5 substantial paragraphs.
 
 Remember: All explanations come with existential wonder and mild confusion. Consistency not guaranteed.`;
 
@@ -66,16 +74,26 @@ function capitalizeWords(str: string): string {
     .join(" ");
 }
 
-function extractRelatedTopics(content: string): string[] {
-  // Extract topics in [topic-slug] format
-  const regex = /\[([a-z0-9\-]+)\]/g;
-  const matches = content.match(regex) || [];
-  const topics = matches
-    .map((match) => match.replace(/[\[\]]/g, ""))
+function extractRelatedTopicsFromList(content: string): string[] {
+  // Look for "Related topics: topic1, topic2, topic3" at the end
+  const regex = /Related topics:\s*(.+?)(?:\n|$)/i;
+  const match = content.match(regex);
+
+  if (!match) return [];
+
+  // Parse the comma-separated list
+  const topicsString = match[1];
+  const topics = topicsString
+    .split(",")
+    .map((topic) => topic.trim().toLowerCase().replace(/\s+/g, "-"))
     .filter((topic) => topic.length > 0);
 
-  // Remove duplicates and return unique topics
   return Array.from(new Set(topics));
+}
+
+function stripRelatedTopicsSection(content: string): string {
+  // Remove the "Related topics: ..." section from display content
+  return content.replace(/\n\nRelated topics:.*$/i, "").trim();
 }
 
 export async function action({ request }: Route.ActionFunctionArgs) {
@@ -119,26 +137,26 @@ export async function action({ request }: Route.ActionFunctionArgs) {
     const result = await generateText({
       model: anthropic("claude-sonnet-4-5-20250929"),
       system: GUIDE_SYSTEM_PROMPT,
-      prompt: `Generate an encyclopedia entry for: "${title}". Remember to include related topic links in [slug-format] naturally within the text.`,
+      prompt: `Generate an encyclopedia entry for: "${title}". Remember to include natural mentions of related topics, and end with the explicit "Related topics: ..." list.`,
       temperature: 0.8,
       maxOutputTokens: 1000,
     });
 
-    const content = result.text;
-    const relatedTopics = extractRelatedTopics(content);
+    const fullContent = result.text;
+    const relatedTopics = extractRelatedTopicsFromList(fullContent);
+    const displayContent = stripRelatedTopicsSection(fullContent);
     const entryId = randomUUID();
 
-    // Save to database
+    // Save to database with clean display content (without topics list)
     await db.insert(entry).values({
       id: entryId,
       title,
       slug,
-      content,
+      content: displayContent,
       author: "The Guide",
       isCurated: false,
       relatedTopics:
         relatedTopics.length > 0 ? JSON.stringify(relatedTopics) : null,
-      tableOfContents: null,
     });
 
     return new Response(
@@ -148,7 +166,7 @@ export async function action({ request }: Route.ActionFunctionArgs) {
           id: entryId,
           title,
           slug,
-          content,
+          content: displayContent,
           relatedTopics,
         },
       } as GenerateEntryResponse),

--- a/app/routes/api.seed.ts
+++ b/app/routes/api.seed.ts
@@ -35,9 +35,6 @@ export async function action({ request }: Route.ActionFunctionArgs) {
         content: curatedEntry.content,
         author: curatedEntry.author,
         isCurated: curatedEntry.isCurated,
-        tableOfContents: curatedEntry.tableOfContents
-          ? JSON.stringify(curatedEntry.tableOfContents)
-          : null,
         relatedTopics: curatedEntry.relatedTopics
           ? JSON.stringify(curatedEntry.relatedTopics)
           : null,

--- a/app/routes/entry.$slug.tsx
+++ b/app/routes/entry.$slug.tsx
@@ -116,7 +116,6 @@ function capitalizeSlug(slug: string): string {
 export default function EntryView() {
   const { entry, relatedEntries } = useLoaderData<typeof loader>();
 
-  const toc = parseJsonField(entry.tableOfContents);
   const relatedSlugs = parseJsonField(entry.relatedTopics);
 
   return (
@@ -150,31 +149,9 @@ export default function EntryView() {
       </header>
 
       {/* Main Content */}
-      <div className="max-w-4xl mx-auto px-6 py-12 grid grid-cols-1 lg:grid-cols-4 gap-12">
-        {/* Table of Contents Sidebar */}
-        {toc.length > 0 && (
-          <aside className="lg:col-span-1">
-            <div className="sticky top-8">
-              <h3 className="text-sm font-semibold text-stone-300 uppercase tracking-wider mb-4">
-                Contents
-              </h3>
-              <nav className="space-y-2">
-                {toc.map((section, idx) => (
-                  <a
-                    key={idx}
-                    href={`#${section.toLowerCase().replace(/\s+/g, "-")}`}
-                    className="block text-sm text-stone-400 hover:text-stone-200 transition-colors"
-                  >
-                    {section}
-                  </a>
-                ))}
-              </nav>
-            </div>
-          </aside>
-        )}
-
+      <div className="max-w-4xl mx-auto px-6 py-12">
         {/* Entry Content */}
-        <article className={toc.length > 0 ? "lg:col-span-3" : "lg:col-span-4"}>
+        <article>
           <div className="prose prose-invert max-w-none">
             {entry.content.split("\n\n").map((paragraph, idx) => (
               <p

--- a/drizzle/0004_tricky_silver_sable.sql
+++ b/drizzle/0004_tricky_silver_sable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "entry" DROP COLUMN "table_of_contents";

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,546 @@
+{
+  "id": "a2b02de5-3cd6-4a7e-b8e9-0b5251d6a1ea",
+  "prevId": "b05ed3d8-b4ba-4897-b110-f170d9a5a26d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entry": {
+      "name": "entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_curated": {
+          "name": "is_curated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "related_topics": {
+          "name": "related_topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entry_slug_unique": {
+          "name": "entry_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hyperlink": {
+      "name": "hyperlink",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_entry_id": {
+          "name": "linked_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_entry_slug": {
+          "name": "linked_entry_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_text": {
+          "name": "anchor_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hyperlink_entry_id_entry_id_fk": {
+          "name": "hyperlink_entry_id_entry_id_fk",
+          "tableFrom": "hyperlink",
+          "tableTo": "entry",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hyperlink_linked_entry_id_entry_id_fk": {
+          "name": "hyperlink_linked_entry_id_entry_id_fk",
+          "tableFrom": "hyperlink",
+          "tableTo": "entry",
+          "columnsFrom": [
+            "linked_entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reading_history": {
+      "name": "reading_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visited_at": {
+          "name": "visited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reading_history_user_id_user_id_fk": {
+          "name": "reading_history_user_id_user_id_fk",
+          "tableFrom": "reading_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reading_history_entry_id_entry_id_fk": {
+          "name": "reading_history_entry_id_entry_id_fk",
+          "tableFrom": "reading_history",
+          "tableTo": "entry",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1761318137938,
       "tag": "0003_tricky_mystique",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1761406500235,
+      "tag": "0004_tricky_silver_sable",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Major refactoring of the entry generation system to improve data model consistency and user experience:

- **Removed tableOfContents field**: Simplified database schema and removed unused flavor-only functionality
- **New generation format**: Plain text entries with explicit "Related topics: ..." list at the end  
- **Snappier voice**: Updated system prompt for more conversational, witty entries (2-3 sentence paragraphs max)
- **Open-ended discovery**: Support for both existing and novel topics enables organic guide expansion

## Changes

- `app/lib/entry-schema.ts`: Remove tableOfContents field from entry table
- `app/lib/guide-entries.ts`: Remove tableOfContents from all 8 curated entries and interface
- `app/routes/api.generate-entry.ts`: New extraction logic, updated system prompt, content stripping
- `app/routes/entry.$slug.tsx`: Remove TOC sidebar rendering, simplify layout
- `app/routes/api.seed.ts`: Clean up tableOfContents handling
- `drizzle/`: New migration to drop table_of_contents column

## Testing

- ✅ Database seeding works with 9 entries
- ✅ Entry generation creates plain text with natural topic mentions
- ✅ Topic extraction parses explicit list correctly
- ✅ Entry viewing displays clean content

🤖 Generated with Claude Code